### PR TITLE
Update install_kali_rootless_auto.sh

### DIFF
--- a/install_kali_rootless_auto.sh
+++ b/install_kali_rootless_auto.sh
@@ -51,10 +51,16 @@ echo "[6/7] Creando script de inicio '$START_SCRIPT_NAME'..."
 cat > "$INSTALL_DIR/$START_SCRIPT_NAME" <<- EOM
 #!/bin/bash
 unset LD_PRELOAD
+# Obtener la ruta absoluta del script y luego el directorio que lo contiene
+SCRIPT_PATH=\$(readlink -f "\$0")
+SCRIPT_DIR=\$(dirname "\$SCRIPT_PATH")
+# El RootFS es el directorio donde se encuentra este script
+ROOTFS_DIR=\$SCRIPT_DIR
+
 proot \\
     --link2symlink \\
     -0 \\
-    -r $HOME/$INSTALL_DIR \\
+    -r \$ROOTFS_DIR \\
     -b /dev \\
     -b /proc \\
     -b /sys \\


### PR DESCRIPTION
Make start-kali.sh script robust by using relative paths

The previous start-kali.sh script used an absolute path with `$HOME`, which caused errors if the installation directory was moved or the script was called from a different location.

This change modifies `install_kali_rootless_auto.sh` to generate a new `start-kali.sh` that determines its own location at runtime. It uses `readlink -f "$0"` and `dirname` to find the correct path to the Kali rootfs, making the startup process independent of the current working directory.